### PR TITLE
refactored monitor_network_advanced() function

### DIFF
--- a/theprotector.sh
+++ b/theprotector.sh
@@ -860,7 +860,7 @@ monitor_network_advanced() {
     fi
 
     # Monitor for covert channels
-    local icmp_traffic="$(grep "ICMP" /proc/net/snmp 2>/dev/null | tail -1 | awk '{print $3}')"
+    local icmp_traffic="$(grep "ICMP" /proc/net/snmp 2>/dev/null | tail -1 | awk '{print $3}' || echo 0)"
     if [[ $icmp_traffic -gt 1000 ]]; then
         log_alert $MEDIUM "High ICMP traffic detected: $icmp_traffic packets"
     fi


### PR DESCRIPTION
Improved comparison between `ss` and `netstat`.
Added comment about inconsistency of `lsof` output vs. the above.
Replaced "declare" with "local" variable definitions.