### PR TITLE
initial nix flake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ sudo ./theprotector.sh install
 sudo ./theprotector.sh systemd
 ```
 
+### Nix Flake Installation
+
+> Note: the Nix flake bundles `theprotector.sh` as a wrapper script that includes all optional dependencies for `theprotector.sh`
+
+Run the following command to install `theprotector.sh` with Nix:
+
+```
+nix profile install github:IHATEGIVINGAUSERNAME/theprotector
+```
+
 ## Usage
 
 ### Basic Commands

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754005108,
+        "narHash": "sha256-7H5ZgKSwLAL3ehi8FDKFNRI4donHRw6pWOnC0rEbOMU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f6f321d89c7f11d15e9e60d07e5ce21598f9596",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "theProtector flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        stdenv = pkgs.stdenv;
+        theProtectorWrapper = pkgs.writeShellScriptBin "theprotector.sh" ''
+          # Contain nix-packaged dependencies in $PATH
+          PATH="${pkgs.bpftrace}/bin:${pkgs.coreutils}/bin:${pkgs.inotify-tools}/bin:${pkgs.jq}/bin:${pkgs.netcat-gnu}/bin:${pkgs.python313}/bin:${pkgs.yara}/bin:$PATH"
+          ${self}/theprotector.sh "$@"
+        '';
+        theProtectorPkg = stdenv.mkDerivation {
+          name = "theProtector";
+          builder = pkgs.bash;
+          args = [ "-c" "${pkgs.coreutils}/bin/mkdir -p $out/bin && ${pkgs.coreutils}/bin/cp ${theProtectorWrapper}/bin/theprotector.sh $out/bin/theprotector.sh" ];
+        };
+      in
+      {
+        packages = rec {
+          default = theprotector;
+          theprotector = theProtectorPkg;
+        };
+        devShell = pkgs.mkShell {
+          name = "default";
+          buildInputs = with pkgs; [
+            theProtectorPkg
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}


### PR DESCRIPTION
This enables installation of `theprotector.sh` as a wrapper with all of its dependencies via Nix flakes.