### PR TITLE
support non-root invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ theProtector provides multi-layer security monitoring for Linux systems by combi
 ### System Requirements
 - Linux kernel 4.9+ (for eBPF functionality)
 - Bash 4.0+
-- Root privileges (required for kernel monitoring and honeypots)
 
 ### Optional Dependencies
 ```bash
@@ -86,6 +85,8 @@ nix profile install github:IHATEGIVINGAUSERNAME/theprotector
 ## Usage
 
 ### Basic Commands
+
+> Unprivileged usage -- running without `sudo` -- is also supported
 
 ```bash
 # Run standard security scan

--- a/flake.nix
+++ b/flake.nix
@@ -15,14 +15,19 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         stdenv = pkgs.stdenv;
+        # Create Python wrapper for python dependencies
+        myPython = pkgs.python313.withPackages (python-pkgs: [
+          python-pkgs.bcc
+        ]);
         theProtectorWrapper = pkgs.writeShellScriptBin "theprotector.sh" ''
           # Contain nix-packaged dependencies in $PATH
-          PATH="${pkgs.bpftrace}/bin:${pkgs.coreutils}/bin:${pkgs.inotify-tools}/bin:${pkgs.jq}/bin:${pkgs.netcat-gnu}/bin:${pkgs.python313}/bin:${pkgs.yara}/bin:$PATH"
+          PATH="${pkgs.bpftrace}/bin:${pkgs.coreutils}/bin:${pkgs.inotify-tools}/bin:${pkgs.jq}/bin:${pkgs.netcat-gnu}/bin:${myPython}/bin:${pkgs.yara}/bin:$PATH"
           ${self}/theprotector.sh "$@"
         '';
         theProtectorPkg = stdenv.mkDerivation {
           name = "theProtector";
           builder = pkgs.bash;
+          meta.mainProgram = "theprotector.sh";
           args = [ "-c" "${pkgs.coreutils}/bin/mkdir -p $out/bin && ${pkgs.coreutils}/bin/cp ${theProtectorWrapper}/bin/theprotector.sh $out/bin/theprotector.sh" ];
         };
       in


### PR DESCRIPTION
- Supports running as non-root (with the exception of EBPF kernel monitoring):
  - Systemd services can be installed via `--user` flag now
  - Honeypots on privileged ports will be skipped if running as non-root
- Updated README
- Updated Nix flake to include Python BCC package for ebpf tracing to work in the flake